### PR TITLE
Support for custom http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.idea
+.DS_Store


### PR DESCRIPTION
Hi Regan,

I'm using you lib for Xero integrations but could not run it in Google app engine standard. 

It required a custom HTTP client that has a RoundTripper interface implementation from the app engine lib. So no Transport setting in that HTTP client to not override the custom RoundTripper.

Feel free to have a look and discuss. I have a working version in my master branch and It's currently running in my project in GAE standard.

