### PR TITLE
Render tracking options correctly as xml

### DIFF
--- a/accounting/line_item.go
+++ b/accounting/line_item.go
@@ -30,7 +30,7 @@ type LineItem struct {
 	LineAmount float32 `json:"LineAmount,omitempty" xml:"LineAmount,omitempty"`
 
 	// Optional Tracking Category – see Tracking.  Any LineItem can have a maximum of 2 <TrackingCategory> elements.
-	Tracking []TrackingCategory `json:"Tracking,omitempty" xml:"Tracking,omitempty"`
+	Tracking []TrackingCategory `json:"Tracking,omitempty" xml:"Tracking>TrackingCategory,omitempty"`
 
 	// Percentage discount being applied to a line item (only supported on ACCREC invoices – ACC PAY invoices and credit notes in Xero do not support discounts
 	DiscountRate float32 `json:"DiscountRate,omitempty" xml:"DiscountRate,omitempty"`

--- a/accounting/tracking_category.go
+++ b/accounting/tracking_category.go
@@ -21,7 +21,7 @@ type TrackingCategory struct {
 	Status string `json:"Status,omitempty" xml:"Status,omitempty"`
 
 	// See Tracking Options
-	Options []TrackingOption `json:"Options,omitempty" xml:"-"`
+	Options []TrackingOption `json:"Options,omitempty" xml:"Option"`
 }
 
 //TrackingCategories is a collection of TrackingCategories

--- a/accounting/tracking_option.go
+++ b/accounting/tracking_option.go
@@ -68,3 +68,7 @@ func (t *TrackingOption) Update(provider *xerogolang.Provider, session goth.Sess
 
 	return unmarshalTrackingCategory(trackingCategoryResponseBytes)
 }
+
+func (t *TrackingOption) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(t.Name, start)
+}


### PR DESCRIPTION
The rendering of Tracking options and category didn't correspond with the structure expected by the Xero API and mentioned in the documentation. See the example XML on https://developer.xero.com/documentation/api/invoices

This is the XML generated before the change:

``` XML
<Invoice>
        <Type>ACCREC</Type>
        <Contact>
            <Name>Peninsula</Name>
        </Contact>
        <LineItems>
            <LineItem>
                <Description>Night 02/11/2017</Description>
                <Quantity>1</Quantity>
                <UnitAmount>91.67</UnitAmount>
                <TaxType>OUTPUT2</TaxType>
                <TaxAmount>18.33</TaxAmount>
                <Tracking>
                    <Name>General</Name>
                </Tracking>
            </LineItem>
        </LineItems>
        <Date>2017-11-03T12:32:14+01:00</Date>
        <LineAmountTypes>Exclusive</LineAmountTypes>
        <Reference>15</Reference>
        <Status>DRAFT</Status>
    </Invoice>
```
This is the changed version of the output XML:

``` xml
      <Invoice>
          <Type>ACCREC</Type>
          <Contact>
              <Name>Peninsula</Name>
          </Contact>
          <LineItems>
              <LineItem>
                  <Description>Night 02/11/2017</Description>
                  <Quantity>1</Quantity>
                  <UnitAmount>91.67</UnitAmount>
                  <TaxType>OUTPUT2</TaxType>
                  <TaxAmount>18.33</TaxAmount>
                  <Tracking>
                      <TrackingCategory>
                          <Name>General</Name>
                          <Option>PMS Interface</Option>
                      </TrackingCategory>
                  </Tracking>
              </LineItem>
          </LineItems>
          <Date>2017-11-03T12:32:14+01:00</Date>
          <LineAmountTypes>Exclusive</LineAmountTypes>
          <Reference>15</Reference>
          <Status>DRAFT</Status>
      </Invoice>
```

I would like to have written a test for it, but there are no tests at the moment regarding marshalling/unmarshalling XML.